### PR TITLE
Make `webfactory/http-cache-bundle` an optional/suggested dependency only

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -30,6 +30,8 @@ jobs:
                         composer-${{ env.PHP_VERSION }}-
             -   run: |
                     composer install --no-interaction --no-scripts --no-progress --no-suggest
+                    # Work around hacky "suggest" dependency vs. checking requirements
+                    composer require webfactory/http-cache-bundle
                     composer show
             -   name: ComposerRequireChecker
                 uses: docker://webfactory/composer-require-checker:3.2.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
                 include:
                     - { php-version: 7.2, symfony-locked-version: none, dependency-version: prefer-lowest }
                     - { php-version: 7.4, symfony-locked-version: 4.4.*, dependency-version: prefer-stable }
+                    - { php-version: 7.4, symfony-locked-version: none, dependency-version: prefer-stable }
                     - { php-version: 8.1, symfony-locked-version: none, dependency-version: prefer-stable }
         name: PHPUnit (PHP ${{matrix.php-version}}, Symfony Version Lock ${{ matrix.symfony-locked-version }}, ${{ matrix.dependency-version }})
         steps:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/http-kernel": "^4.3|^5.0",
         "symfony/lock": "^4.3|^5.0",
         "symfony/twig-bundle": "^4.3|^5.0",
-        "twig/twig": "^1.0|^2.0|^3.0",
+        "twig/twig": "^1.0|^2.0|^3.0"
     },
 
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,10 @@
         "symfony/lock": "^4.3|^5.0",
         "symfony/twig-bundle": "^4.3|^5.0",
         "twig/twig": "^1.0|^2.0|^3.0",
-        "webfactory/http-cache-bundle": "^1.0"
+    },
+
+    "suggest": {
+        "webfactory/http-cache-bundle": "If you want to use wfd_meta information to determine Last-Modified information for requests"
     },
 
     "require-dev": {

--- a/src/Caching/EventListener.php
+++ b/src/Caching/EventListener.php
@@ -12,8 +12,8 @@ use Doctrine\Common\Annotations\Reader;
 use ReflectionObject;
 use SplObjectStorage;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Webfactory\Bundle\WfdMetaBundle\Caching\Annotation\Send304IfNotModified;
 use Webfactory\Bundle\WfdMetaBundle\MetaQueryFactory;
 
@@ -40,7 +40,7 @@ class EventListener
         $this->lastTouchedResults = new SplObjectStorage();
     }
 
-    public function onKernelController(FilterControllerEvent $event)
+    public function onKernelController(ControllerEvent $event)
     {
         $controller = $event->getController();
         $request = $event->getRequest();
@@ -81,7 +81,7 @@ class EventListener
         }
     }
 
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event)
     {
         $request = $event->getRequest();
         $response = $event->getResponse();


### PR DESCRIPTION
I know suggested dependencies are an ugly hack and it is not possible to specify proper version constraints.

However, as long as `webactory/http-cache-bundle` does not declare compatibility with Symfony 5.x and/or PHP 8, users of this bundle here are stuck as well.