### PR TITLE
Erweitere Type Hint

### DIFF
--- a/src/Helper/LastmodHelper.php
+++ b/src/Helper/LastmodHelper.php
@@ -82,7 +82,7 @@ class LastmodHelper
         $this->tableIdConstants = $tableIdConstants;
     }
 
-    public function setTables(array|string $tables): void
+    public function setTables($tables): void
     {
         $this->tables = $tables;
     }

--- a/src/Helper/LastmodHelper.php
+++ b/src/Helper/LastmodHelper.php
@@ -82,7 +82,7 @@ class LastmodHelper
         $this->tableIdConstants = $tableIdConstants;
     }
 
-    public function setTables(array $tables): void
+    public function setTables($tables): void
     {
         $this->tables = $tables;
     }

--- a/src/Helper/LastmodHelper.php
+++ b/src/Helper/LastmodHelper.php
@@ -82,7 +82,7 @@ class LastmodHelper
         $this->tableIdConstants = $tableIdConstants;
     }
 
-    public function setTables($tables): void
+    public function setTables(array|string $tables): void
     {
         $this->tables = $tables;
     }


### PR DESCRIPTION
Der Parameter `$tables` kann auch "*" (für alle Tabellen) sein, darum
ist eine Beschränkung auf Arrays hier falsch.
