### PR TITLE
Revert some added method type hints from #21

### DIFF
--- a/src/Helper/LastmodHelper.php
+++ b/src/Helper/LastmodHelper.php
@@ -72,17 +72,17 @@ class LastmodHelper
         $this->resetInterval = $resetInterval;
     }
 
-    public function setEntities(array $entities): void
+    public function setEntities($entities): void
     {
         $this->entities = $entities;
     }
 
-    public function setTableIdConstants(array $tableIdConstants): void
+    public function setTableIdConstants($tableIdConstants): void
     {
         $this->tableIdConstants = $tableIdConstants;
     }
 
-    public function setTables(array $tables): void
+    public function setTables($tables): void
     {
         $this->tables = $tables;
     }


### PR DESCRIPTION
These methods may, in fact, also accept `string` type parameters. The cast to `array` will happen only later on in `MetaQuery::addTable()` and similar methods.