### PR TITLE
Add a config setting to make wfd_meta-based caches expire immediately

### DIFF
--- a/src/Config/CacheBustingResourceChecker.php
+++ b/src/Config/CacheBustingResourceChecker.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Webfactory\Bundle\WfdMetaBundle\Config;
+
+use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Config\ResourceCheckerInterface;
+
+class CacheBustingResourceChecker implements ResourceCheckerInterface
+{
+    public function supports(ResourceInterface $metadata): bool
+    {
+        return $metadata instanceof WfdMetaResource;
+    }
+
+    public function isFresh(ResourceInterface $resource, int $timestamp): bool
+    {
+        return false;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Webfactory\Bundle\WfdMetaBundle\DependencyInjection;
+
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('webfactory_wfd_meta');
+
+        $treeBuilder->getRootNode()
+            ->children()
+            ->booleanNode('always_expire_wfd_meta_resources')
+            ->defaultFalse()
+            ->info('When set to "true", ConfigCache instances that depend on "\Webfactory\Bundle\WfdMetaBundle\Config\WfdMetaResource" will be refreshed every time; useful during functional tests to reload routes etc.');
+
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,7 +2,6 @@
 
 namespace Webfactory\Bundle\WfdMetaBundle\DependencyInjection;
 
-
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 

--- a/src/DependencyInjection/WebfactoryWfdMetaExtension.php
+++ b/src/DependencyInjection/WebfactoryWfdMetaExtension.php
@@ -13,6 +13,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Webfactory\Bundle\WfdMetaBundle\Config\CacheBustingResourceChecker;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 class WebfactoryWfdMetaExtension extends Extension
 {
@@ -29,5 +31,14 @@ class WebfactoryWfdMetaExtension extends Extension
 
         $yamlLoader = new YamlFileLoader($container, $fileLocator);
         $yamlLoader->load('legacy_aliases.yml');
+
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        if ($config['always_expire_wfd_meta_resources']) {
+            $yamlLoader->load('cache_busting.yml');
+        } else {
+            $xmlLoader->load('config_cache_factory.xml');
+        }
     }
 }

--- a/src/DependencyInjection/WebfactoryWfdMetaExtension.php
+++ b/src/DependencyInjection/WebfactoryWfdMetaExtension.php
@@ -13,8 +13,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Webfactory\Bundle\WfdMetaBundle\Config\CacheBustingResourceChecker;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 class WebfactoryWfdMetaExtension extends Extension
 {

--- a/src/Resources/config/cache_busting.yml
+++ b/src/Resources/config/cache_busting.yml
@@ -1,0 +1,7 @@
+services:
+
+    _defaults:
+        public: false
+
+    Webfactory\Bundle\WfdMetaBundle\Config\CacheBustingResourceChecker:
+        tags: ['config_cache.resource_checker']

--- a/src/Resources/config/config_cache_factory.xml
+++ b/src/Resources/config/config_cache_factory.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <defaults autoconfigure="true" autowire="true" public="false" />
+
+        <service id="Webfactory\Bundle\WfdMetaBundle\Config\WfdMetaConfigCacheFactory" decorates="config_cache_factory">
+            <argument type="service" id="Webfactory\Bundle\WfdMetaBundle\Config\WfdMetaConfigCacheFactory.inner" />
+            <argument type="service" id="Webfactory\Bundle\WfdMetaBundle\MetaQueryFactory" />
+            <argument type="service">
+                <service class="Symfony\Component\Lock\LockFactory">
+                    <argument type="service">
+                        <service class="Symfony\Component\Lock\Store\FlockStore" />
+                    </argument>
+                    <call method="setLogger">
+                        <argument type="service" id="logger" on-invalid="ignore" />
+                    </call>
+                    <tag name="monolog.logger" channel="webfactory_wfd_meta" />
+                </service>
+            </argument>
+        </service>
+
+        <service public="true" id="webfactory_wfd_meta.config_cache_factory" alias="Webfactory\Bundle\WfdMetaBundle\Config\WfdMetaConfigCacheFactory">
+            <deprecated>The "%alias_id%" alias is deprecated</deprecated>
+        </service>
+
+    </services>
+</container>

--- a/src/Resources/config/legacy_aliases.yml
+++ b/src/Resources/config/legacy_aliases.yml
@@ -26,7 +26,3 @@ services:
     webfactory_wfd_meta.controller.template:
         alias: 'Webfactory\Bundle\WfdMetaBundle\Controller\TemplateController'
         deprecated: ~
-
-    webfactory_wfd_meta.config_cache_factory:
-        alias: 'Webfactory\Bundle\WfdMetaBundle\Config\WfdMetaConfigCacheFactory'
-        deprecated: ~

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -36,21 +36,5 @@
             <argument>%kernel.debug%</argument>
         </service>
 
-        <service id="Webfactory\Bundle\WfdMetaBundle\Config\WfdMetaConfigCacheFactory" decorates="config_cache_factory">
-            <argument type="service" id="Webfactory\Bundle\WfdMetaBundle\Config\WfdMetaConfigCacheFactory.inner" />
-            <argument type="service" id="Webfactory\Bundle\WfdMetaBundle\MetaQueryFactory" />
-            <argument type="service">
-                <service class="Symfony\Component\Lock\LockFactory">
-                    <argument type="service">
-                        <service class="Symfony\Component\Lock\Store\FlockStore" />
-                    </argument>
-                    <call method="setLogger">
-                        <argument type="service" id="logger" on-invalid="ignore" />
-                    </call>
-                    <tag name="monolog.logger" channel="webfactory_wfd_meta" />
-                </service>
-            </argument>
-        </service>
-
     </services>
 </container>


### PR DESCRIPTION
This adds a new configuration setting:

```yml
# config_test.yml
webfactory_wfd_meta:
    always_expire_wfd_meta_resources: true
```

With this setting, `ConfigCache` instances (Symfony Router, Translator, ... maybe?) that include `WfdMetaResource` instances will expire immediately.

This is helpful e. g. in functional tests, where you have database-backed routes, translations or similar: You can change the database values and no longer need to think about the `ConfigCaches` or poke `wfd_meta` to make the changes effective.