### PR TITLE
Always expire wfdMeta resources in `test` per default

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ With this setting, ConfigCache instances (Symfony Router, Translator, ... maybe?
 
 This is helpful e. g. in functional tests, where you have database-backed routes, translations or similar: You can change the database values and no longer need to think about the ConfigCaches or poke wfd_meta to make the changes effective.
 
+Defaults to `false` but in a `test`-environment, where it defaults to `true`.
+
 ## Tests
 
 Run the tests with

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,7 +17,7 @@ class Configuration implements ConfigurationInterface
             ->defaultFalse()
             ->info('When set to "true", ConfigCache instances that depend on "\Webfactory\Bundle\WfdMetaBundle\Config\WfdMetaResource" will be refreshed every time; useful during functional tests to reload routes etc.');
 
-        if('test' === $_ENV['APP_ENV']) {
+        if ('test' === $_ENV['APP_ENV']) {
             $treeBuilder->getRootNode()->defaultTrue();
         }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,6 +17,10 @@ class Configuration implements ConfigurationInterface
             ->defaultFalse()
             ->info('When set to "true", ConfigCache instances that depend on "\Webfactory\Bundle\WfdMetaBundle\Config\WfdMetaResource" will be refreshed every time; useful during functional tests to reload routes etc.');
 
+        if('test' === $_ENV['APP_ENV']) {
+            $treeBuilder->getRootNode()->defaultTrue();
+        }
+
         return $treeBuilder;
     }
 }


### PR DESCRIPTION
We set

        webfactory_wfd_meta.always_expire_wfd_meta_resources: true

in our Symfony-default-config in https://github.com/webfactory/webfactory-symfony-default-config/pull/14, but we can't actually do that, because this triggers an error in projects not using `webfactory/wfdmeta-bundle` (see https://github.com/webfactory/webfactory-symfony-default-config/pull/17)

This PR sets the configuration parameter `webfactory_wfd_meta.always_expire_wfd_meta_resources` to `true` as default in `test` environments end keeps it `false` everywhere else.

Closes #35 