### PR TITLE
Add a PHP 8 attribute to support configuration

### DIFF
--- a/src/Caching/Annotation/Send304IfNotModified.php
+++ b/src/Caching/Annotation/Send304IfNotModified.php
@@ -8,39 +8,16 @@
 
 namespace Webfactory\Bundle\WfdMetaBundle\Caching\Annotation;
 
-use Exception;
-use Webfactory\Bundle\WfdMetaBundle\Helper\LastmodHelper;
-use Webfactory\Bundle\WfdMetaBundle\MetaQueryFactory;
-
-@trigger_error(
-    'The Send304IfNotModified annotation is deprecated. Use WebfactoryHttpCachingBundle and its LastModifiedDeterminators instead. If in a hurry, @see \Webfactory\Bundle\WfdMetaBundle\Caching\WfdMetaQueries for a quick conversion.',
-    \E_USER_DEPRECATED
-);
-
 /**
  * @Annotation
  *
- * @deprecated Use WebfactoryHttpCachingBundle and its LastModifiedDeterminators instead. If in a hurry, @see \Webfactory\Bundle\WfdMetaBundle\Caching\WfdMetaQueries for a quick conversion.
+ * @deprecated Use the \Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified attribute instead
  */
-class Send304IfNotModified
+class Send304IfNotModified extends \Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified
 {
-    protected $lastmodHelper;
-
     public function __construct($values)
     {
-        $this->lastmodHelper = new LastmodHelper();
-
-        foreach ($values as $key => $value) {
-            if (method_exists($this->lastmodHelper, $name = 'set'.ucfirst($key))) {
-                $this->lastmodHelper->$name($value);
-            } else {
-                throw new Exception('Die Annotation '.static::class.' kann die Eigentschaft "'.$key.'" nicht setzen.');
-            }
-        }
-    }
-
-    public function calculateLastModified(MetaQueryFactory $metaQueryFactory)
-    {
-        return $this->lastmodHelper->calculateLastModified($metaQueryFactory);
+        @trigger_error(sprintf('The %s annotation is deprecated, use the %s attribute instead', __CLASS__, \Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified::class), E_USER_DEPRECATED);
+        parent::__construct(...$values);
     }
 }

--- a/src/Caching/Annotation/Send304IfNotModified.php
+++ b/src/Caching/Annotation/Send304IfNotModified.php
@@ -17,7 +17,7 @@ class Send304IfNotModified extends \Webfactory\Bundle\WfdMetaBundle\Caching\Attr
 {
     public function __construct($values)
     {
-        @trigger_error(sprintf('The %s annotation is deprecated, use the %s attribute instead', __CLASS__, \Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified::class), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s annotation is deprecated, use the %s attribute instead', __CLASS__, \Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified::class), \E_USER_DEPRECATED);
         parent::__construct(...$values);
     }
 }

--- a/src/Caching/Annotation/ValidUntilLastTouched.php
+++ b/src/Caching/Annotation/ValidUntilLastTouched.php
@@ -11,17 +11,13 @@ namespace Webfactory\Bundle\WfdMetaBundle\Caching\Annotation;
 /**
  * @Annotation
  *
- * @Deprecated
+ * @deprecated Use the \Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified attribute instead
  */
 class ValidUntilLastTouched extends Send304IfNotModified
 {
     public function __construct($values)
     {
-        @trigger_error(
-            'The ValidUntilLastTouched annotation is deprecated. Use Send304IfNotModified instead.',
-            \E_USER_DEPRECATED
-        );
-
-        parent::__construct($values);
+        @trigger_error(sprintf('The %s annotation is deprecated, use the %s attribute instead', __CLASS__, \Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified::class), \E_USER_DEPRECATED);
+        \Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified::__construct(...$values);
     }
 }

--- a/src/Caching/Attribute/Send304IfNotModified.php
+++ b/src/Caching/Attribute/Send304IfNotModified.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * (c) webfactory GmbH <info@webfactory.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webfactory\Bundle\WfdMetaBundle\Caching\Attribute;
+
+use Exception;
+use Webfactory\Bundle\WfdMetaBundle\Helper\LastmodHelper;
+use Webfactory\Bundle\WfdMetaBundle\MetaQueryFactory;
+
+/**
+ * @deprecated Use WebfactoryHttpCachingBundle and its LastModifiedDeterminators instead. If in a hurry, @see \Webfactory\Bundle\WfdMetaBundle\Caching\WfdMetaQueries for a quick conversion.
+ */
+#[\Attribute]
+class Send304IfNotModified
+{
+    protected $lastmodHelper;
+
+    public function __construct(...$values)
+    {
+        @trigger_error(
+            'The Send304IfNotModified attribute is deprecated. Use WebfactoryHttpCachingBundle and its LastModifiedDeterminators instead. If in a hurry, @see \Webfactory\Bundle\WfdMetaBundle\Caching\WfdMetaQueries for a quick conversion.',
+            \E_USER_DEPRECATED
+        );
+
+        $this->lastmodHelper = new LastmodHelper();
+
+        foreach ($values as $key => $value) {
+            if (method_exists($this->lastmodHelper, $name = 'set'.ucfirst($key))) {
+                $this->lastmodHelper->$name($value);
+            } else {
+                throw new Exception('Die Annotation '.static::class.' kann die Eigentschaft "'.$key.'" nicht setzen.');
+            }
+        }
+    }
+
+    public function calculateLastModified(MetaQueryFactory $metaQueryFactory)
+    {
+        return $this->lastmodHelper->calculateLastModified($metaQueryFactory);
+    }
+}

--- a/src/Caching/Attribute/Send304IfNotModified.php
+++ b/src/Caching/Attribute/Send304IfNotModified.php
@@ -8,6 +8,7 @@
 
 namespace Webfactory\Bundle\WfdMetaBundle\Caching\Attribute;
 
+use Attribute;
 use Exception;
 use Webfactory\Bundle\WfdMetaBundle\Helper\LastmodHelper;
 use Webfactory\Bundle\WfdMetaBundle\MetaQueryFactory;
@@ -15,7 +16,7 @@ use Webfactory\Bundle\WfdMetaBundle\MetaQueryFactory;
 /**
  * @deprecated Use WebfactoryHttpCachingBundle and its LastModifiedDeterminators instead. If in a hurry, @see \Webfactory\Bundle\WfdMetaBundle\Caching\WfdMetaQueries for a quick conversion.
  */
-#[\Attribute]
+#[Attribute]
 class Send304IfNotModified
 {
     protected $lastmodHelper;

--- a/src/Caching/EventListener.php
+++ b/src/Caching/EventListener.php
@@ -96,16 +96,16 @@ class EventListener
      *
      * @return Send304IfNotModified|null The attribute, if found. Null otherwise.
      */
-    protected function findAttribute($callback): ?\Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified
+    protected function findAttribute($callback): ?Attribute\Send304IfNotModified
     {
-        if (! \is_array($callback)) {
+        if (!\is_array($callback)) {
             return null;
         }
 
         $object = new ReflectionObject($callback[0]);
         $method = $object->getMethod($callback[1]);
 
-        if (PHP_MAJOR_VERSION >= 8) {
+        if (\PHP_MAJOR_VERSION >= 8) {
             $attributes = $method->getAttributes(\Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified::class);
 
             if ($attributes) {
@@ -115,7 +115,8 @@ class EventListener
 
         foreach ($this->reader->getMethodAnnotations($method) as $configuration) {
             if ($configuration instanceof Send304IfNotModified) {
-                @trigger_error(sprintf('Using annotations to configure wfd_meta based caching on %s::%s is deprecated, use attribute-based configuration instead.', $method->class, $method->name), E_USER_DEPRECATED);
+                @trigger_error(sprintf('Using annotations to configure wfd_meta based caching on %s::%s is deprecated, use attribute-based configuration instead.', $method->class, $method->name), \E_USER_DEPRECATED);
+
                 return $configuration;
             }
         }

--- a/src/Caching/EventListener.php
+++ b/src/Caching/EventListener.php
@@ -45,13 +45,13 @@ class EventListener
         $controller = $event->getController();
         $request = $event->getRequest();
 
-        $annotation = $this->findAnnotation($controller);
+        $attribute = $this->findAttribute($controller);
 
-        if (!$annotation) {
+        if (!$attribute) {
             return;
         }
 
-        $lastTouched = $annotation->calculateLastModified($this->metaQueryFactory);
+        $lastTouched = $attribute->calculateLastModified($this->metaQueryFactory);
 
         if (!$lastTouched) {
             return;
@@ -94,18 +94,29 @@ class EventListener
     /**
      * @param $callback array A PHP callback (array) pointing to the method to reflect on.
      *
-     * @return Send304IfNotModified|null The annotation, if found. Null otherwise.
+     * @return Send304IfNotModified|null The attribute, if found. Null otherwise.
      */
-    protected function findAnnotation($callback)
+    protected function findAttribute($callback): ?\Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified
     {
-        if (\is_array($callback)) {
-            $object = new ReflectionObject($callback[0]);
-            $method = $object->getMethod($callback[1]);
+        if (! \is_array($callback)) {
+            return null;
+        }
 
-            foreach ($this->reader->getMethodAnnotations($method) as $configuration) {
-                if ($configuration instanceof Send304IfNotModified) {
-                    return $configuration;
-                }
+        $object = new ReflectionObject($callback[0]);
+        $method = $object->getMethod($callback[1]);
+
+        if (PHP_MAJOR_VERSION >= 8) {
+            $attributes = $method->getAttributes(\Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified::class);
+
+            if ($attributes) {
+                return $attributes[0];
+            }
+        }
+
+        foreach ($this->reader->getMethodAnnotations($method) as $configuration) {
+            if ($configuration instanceof Send304IfNotModified) {
+                @trigger_error(sprintf('Using annotations to configure wfd_meta based caching on %s::%s is deprecated, use attribute-based configuration instead.', $method->class, $method->name), E_USER_DEPRECATED);
+                return $configuration;
             }
         }
 


### PR DESCRIPTION
This PR adds a `\Webfactory\Bundle\WfdMetaBundle\Caching\Attribute\Send304IfNotModified` attribute to replace the `\Webfactory\Bundle\WfdMetaBundle\Caching\Annotation\Send304IfNotModified` annotation class.