### PR TITLE
Always decorate Symfonys `config_cache_factory` service with `WfdMetaConfigCacheFactory` (Case 171239)

### DIFF
--- a/src/DependencyInjection/WebfactoryWfdMetaExtension.php
+++ b/src/DependencyInjection/WebfactoryWfdMetaExtension.php
@@ -33,10 +33,10 @@ class WebfactoryWfdMetaExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
+        $xmlLoader->load('config_cache_factory.xml');
+
         if ($config['always_expire_wfd_meta_resources']) {
             $yamlLoader->load('cache_busting.yml');
-        } else {
-            $xmlLoader->load('config_cache_factory.xml');
         }
     }
 }


### PR DESCRIPTION
The WfdMetaConfigCacheFactory creates a cache that checks its freshness by:
1. checking the "inner" cache with Symfony means
2. if that is still fresh, the WfdMetaConfigCache queries the wfd_meta table in regard to the registered wfdMeta-resources like a DoctrineEntityClassResource for a Page entity.

The decoration only taking place when `always_expire_wfd_meta_resources` was not set effectively disabled checking the wfdMeta-resources, at least in production environments. (The fact that one probably shouldn't use this configuration setting in production is another story.)

This should not break anything, as the decoration already happened always, before the `always_expire_wfd_meta_resources` config setting was introduced in c7a2e2b07d86352e94b7f57b67c5b95a57a0e2e2.

Resolves #43 