### PR TITLE
Keep `WfdMetaResource` instances in the regular metadata file (Case 172852)

### DIFF
--- a/src/Config/WfdMetaConfigCache.php
+++ b/src/Config/WfdMetaConfigCache.php
@@ -73,17 +73,19 @@ class WfdMetaConfigCache implements ConfigCacheInterface
 
     public function write($content, array $metadata = null): void
     {
-        /** @var WfdMetaResource[] $wfdMetaResources */
+        $this->innerCache->write($content, $metadata);
+
+        // Create an extra cache layer by collecting all WfdMetaResources, fetching the current
+        // timestamp for the data they represent and put everything together into an extra
+        // `.wfd_meta` metadata file.
+
         $wfdMetaResources = [];
 
         foreach ($metadata as $key => $resource) {
             if ($resource instanceof WfdMetaResource) {
-                unset($metadata[$key]);
                 $wfdMetaResources[(string) $resource] = $resource; // use key to dedup resource
             }
         }
-
-        $this->innerCache->write($content, $metadata);
 
         $timestamp = null;
 


### PR DESCRIPTION
#45 broke the `always_expire_wfd_meta_resources` feature in a subtle way:

The change made the `WfdMetaConfigCacheFactory` decorate the regular `config_cache_factory` service unconditionally. The idea was that the `CacheBustingResourceChecker` would then be added when setting `always_expire_wfd_meta_resources: true`, causing caches that rely on `wfd_meta` to be refreshed every time.

What we missed was that `WfdMetaConfigCache` sorts the resources into two groups - those for the regular freshness check (which happens by means of the Symfony `ConfigCacheFactory`), and the "extra" resources checked with `wfd_meta` data.

`WfdMetaResources` would always end up in the second group, which is checked by `WfdMetaConfigCache`, and this check was not aware of `ResourceChecker`s at all. This rendered the `CacheBustingResourceChecker` useless, since it was never applied to anything.

This PR fixes the problem by keeping `WfdMetaResource` instances in the set of resources to be checked by the "inner" (regular) config cache factory, where they can be picked up by `CacheBustingResourceChecker`.

It also gives a bit more clarity to how the `WfdMetaConfigCache` actually works: It now behaves more cleanly like a decorator around the "inner" `ConfigCache` instance, delegating the `isFresh()` check to that implementation first and then running a second round of checks.


