### PR TITLE
Reduziere Deprecations, löse kleinere Code Inspectons (Case 183951)

### DIFF
--- a/src/Config/WfdMetaConfigCacheFactory.php
+++ b/src/Config/WfdMetaConfigCacheFactory.php
@@ -88,7 +88,7 @@ class WfdMetaConfigCacheFactory implements ConfigCacheFactoryInterface
         $cs->execute($cache->getPath(), function () use ($callback, $cache) {
             if (!$cache->isFresh()) {
                 // Our turn and the cache is still stale. Rebuild. */
-                \call_user_func($callback, $cache);
+                $callback($cache);
             } // else: Our turn, but cache is fresh. Must have been rebuilt while we were blocked. Use it.
         });
     }

--- a/src/Controller/TemplateController.php
+++ b/src/Controller/TemplateController.php
@@ -111,7 +111,7 @@ class TemplateController
 
         if ($private) {
             $response->setPrivate();
-        } elseif (false === $private || (null === $private && ($maxAge || $sharedAge))) {
+        } elseif (false === $private || ($maxAge || $sharedAge)) {
             $response->setPublic();
         }
 

--- a/src/DependencyInjection/WebfactoryWfdMetaExtension.php
+++ b/src/DependencyInjection/WebfactoryWfdMetaExtension.php
@@ -10,9 +10,9 @@ namespace Webfactory\Bundle\WfdMetaBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class WebfactoryWfdMetaExtension extends Extension
 {

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -148,8 +148,6 @@ class Provider implements ServiceSubscriberInterface
             return null;
         }
 
-        $dateTime = new DateTime($fetchValue);
-
-        return $dateTime->getTimestamp();
+        return (new DateTime($fetchValue))->getTimestamp();
     }
 }

--- a/src/Util/CriticalSection.php
+++ b/src/Util/CriticalSection.php
@@ -132,8 +132,6 @@ class CriticalSection
      */
     private function debug(string $message): void
     {
-        if ($this->logger) {
-            $this->logger->debug($message, ['pid' => getmypid()]);
-        }
+        $this->logger?->debug($message, ['pid' => getmypid()]);
     }
 }


### PR DESCRIPTION
- Beerbe nicht-deprecated Klasse
- Nutze first class callable syntax
- Inline value
- Entferne redundante Condition
- Nutze Null-safe-Operator
